### PR TITLE
Fixed issue with illegal highlight on valid const/template/var types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # vscode-language-ttcn
 ## TTCN-3 Language Support for Visual Studio Code
 ## Change Log
+#### 0.6.0
+- Added a separate rule for invalid identifiers for const/template/var
+- Added support for highlighting colon (:) (undocumented in TTCN-3)
+
 #### 0.5.0
 - Added highlighting for invalid identifers
 - Added highlighting for invalid numeric strings

--- a/README.md
+++ b/README.md
@@ -11,17 +11,9 @@ Provides TTCN-3 language support for Visual Studio Code
 - Syntax highlighting<br /><p><img src="https://raw.githubusercontent.com/ealap/vscode-language-ttcn/dev-ealap/images/vscode-ss-ttcn3.png" alt="Figure 001. TTCN-3 Sample Code" /></p><sup><i>Theme: <a href="https://marketplace.visualstudio.com/items?itemName=teabyii.ayu">Ayu Dark by teabyii</a></i></sup>
 
 ### Release Notes
-#### 0.5.0
-- Added highlighting for invalid identifers
-- Added highlighting for invalid numeric strings
-- Added highlighting for invalid symbols
-- Added highlighting for range symbol
-- Modified pattern for matching statement separators
-- Modified pattern for matching string operator (&)
-- Replaced impossible match under invalid patterns
-- Removed end-of-line match when highlighting identifiers
-- Modified regular expression to only match hexadecimal digits A-F or a-f
-- Fixed incorrect name key for bitstring and octetstring
+#### 0.6.0
+- Added a separate rule for invalid identifiers for const/template/var
+- Added support for highlighting colon (:) (undocumented in TTCN-3)
 
 #### Older releases
 See [CHANGELOG](https://raw.githubusercontent.com/ealap/vscode-language-ttcn/master/CHANGELOG.md)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "language-ttcn",
     "displayName": "TTCN-3 Language Support for Visual Studio Code",
     "description": "Provides TTCN-3 language support for Visual Studio Code",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "publisher": "ealap",
     "license": "MIT",
     "preview": true,

--- a/syntaxes/ttcn.tmLanguage.json
+++ b/syntaxes/ttcn.tmLanguage.json
@@ -364,7 +364,7 @@
                 {
                     "comment": "statement separator symbol [.;,]",
                     "name": "string.unquoted.separator.ttcn",
-                    "match": "(?<![\\.;,])([\\.;,])(?![\\.;,])"
+                    "match": "(?<![\\.\\:\\;\\,])([\\.\\:\\;\\,])(?![\\.\\:\\;\\,])"
                 },
                 {
                     "comment": "wildcard/matching symbol [?*]",
@@ -439,7 +439,11 @@
         "invalid": {
             "patterns": [{
                     "name": "invalid.illegal.identifier.ttcn",
-                    "match": "(?<=altstep|const|from|function|module|template|testcase|timer|var)\\s+([[:digit:]_][[:alnum:]_]+|\\p{Alpha}[[:alnum:]_]*[^[:alnum:]_;\\(]*[[:alnum:]_]*)(?=[;\\(\\s])"
+                    "match": "(?<=altstep|function|module|testcase)\\s+([[:digit:]_][[:alnum:]_]+|\\p{Alpha}[[:alnum:]_]*[^[:alnum:]_;\\(]*[[:alnum:]_]*)(?=[;\\(\\s])"
+                },
+                {
+                    "name": "invalid.illegal.identifier.ttcn",
+                    "match": "(?<=const|from|template|var)\\s+([[:digit:]_][[:alnum:]_]+|\\p{Alpha}[[:alnum:]_]*[^[:alnum:]_;\\:\\(\\.]*[[:alnum:]_]*)(?=[\\s])"
                 },
                 {
                     "name": "invalid.illegal.numstring.ttcn",
@@ -447,7 +451,7 @@
                 },
                 {
                     "name": "invalid.illegal.symbol.ttcn",
-                    "match": "[\\;,&]{2,}"
+                    "match": "[\\;\\:\\,\\&]{2,}"
                 },
                 {
                     "name": "invalid.illegal.impossible.ttcn",


### PR DESCRIPTION
± Added a separate rule for invalid identifiers for const/template/var
\+ Added support for highlighting colon (:) (undocumented in TTCN-3)