### PR TITLE
Updated to package v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 ## TTCN-3 Language Support for Visual Studio Code
 ## Change Log
 
+#### 0.14.0
+- Fixed missing highlight for arithmetic operators
+- Fixed incorrect highlight for unmap keyword
+- Fixed inconsistent highlighting for user-defined keywords
+- Added an exception for keywords class, configuration
+- Improve snippets
+
 #### 0.13.0
 - Fixed [issue](https://github.com/ealap/vscode-language-ttcn/issues/26) with missing grammar for type parameterization
 - Reworked matching escape characters inside strings

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Provides TTCN-3 language support for Visual Studio Code
 - Syntax highlighting<br /><p><img src="https://raw.githubusercontent.com/ealap/vscode-language-ttcn/master/images/vscode-ss-ttcn3.png" alt="Figure 001. TTCN-3 Sample Code" style="max-width: 40%; height: auto; overflow: hidden;"/></p>
 
 ### Release Notes
-#### 0.13.0
-- Fixed [issue (#26)](https://github.com/ealap/vscode-language-ttcn/issues/26) about missing grammar for type parameterization
-- Reworked matching escape characters inside strings
-- Improved snippets
+#### 0.14.0
+- Fixed missing highlight for arithmetic operators
+- Fixed incorrect highlight for unmap keyword
+- Fixed inconsistent highlighting for user-defined keywords
+- Added an exception for keywords class, configuration
+- Improve snippets
 
 #### Older releases
 See [CHANGELOG](https://raw.githubusercontent.com/ealap/vscode-language-ttcn/master/CHANGELOG.md)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "language-ttcn",
     "displayName": "TTCN-3 Language Support for Visual Studio Code",
     "description": "Provides TTCN-3 language support for Visual Studio Code",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "publisher": "ealap",
     "license": "MIT",
     "preview": true,

--- a/snippets/ttcn.tmSnippet.json
+++ b/snippets/ttcn.tmSnippet.json
@@ -664,7 +664,7 @@
         "body": ["with ${0}"],
         "description": ""
     },
-    "function action": {
+    "action": {
         "prefix": "action",
         "body": ["action(${1})${0}"],
         "description": ""
@@ -679,10 +679,12 @@
         "body": ["alive(${1})${0}"],
         "description": ""
     },
-    "function any2unistr": {
+    "any2unistr": {
         "prefix": ["any2unistr", "2unistr"],
-        "body": ["any2unistr(${1})${0}"],
-        "description": ""
+        "body": ["any2unistr(${1:invalue}, ${2:format})${0}"],
+        "description": [
+            "any2unistr(in template any_time invalue, in universalcharstring format := \"\") return universal charstring\n\n"
+        ]
     },
     "bit2hex": {
         "prefix": ["bit2hex", "2hex"],
@@ -767,20 +769,26 @@
         "body": ["create(${1})${0}"],
         "description": ""
     },
-    "function decvalue": {
+    "decvalue": {
         "prefix": "decvalue",
-        "body": ["decvalue(${1})${0}"],
-        "description": ""
+        "body": ["decvalue(${1:encoded_value}, ${2:decoded_value}, ${3:decoding_info}, ${4:dynamic_encoding})${0}"],
+        "description": [
+            "decvalue(inout bitstring encoded_value, out any_type decoded_value, in universal charstring decoding_info := \"\", in universal charstring dynamic_encoding := \"\") return integer\n\n"
+        ]
     },
-    "function decvalue_o": {
+    "decvalue_o": {
         "prefix": "decvalue_o",
-        "body": ["decvalue_o(${1})${0}"],
-        "description": ""
+        "body": ["decvalue_o(${1:encoded_value}, ${2:decoded_value}, ${3:decoding_info}, ${4:dynamic_encoding})${0}"],
+        "description": [
+            "decvalue_o(inout octetstring encoded_value, out any_type decoded_value, in universal charstring decoding_info := \"\", in universal charstring dynamic_encoding := \"\") return integer\n\n"
+        ]
     },
-    "function decvalue_unichar": {
+    "decvalue_unichar": {
         "prefix": "decvalue_unichar",
-        "body": ["decvalue_unichar(${1})${0}"],
-        "description": ""
+        "body": ["decvalue_unichar(${1:encoded_value}, ${2:decoded_value}, ${3:string_serialization}, ${4:decoding_info}, ${5:dynamic_encoding})${0}"],
+        "description": [
+            "decvalue_unichar(inout universal charstring encoded_value, out any_type decoded_value, in charstring  string_serialization := \"UTF-8\", in universal charstring decoding_info := \"\", in universal charstring dynamic_encoding := \"\") return integer\n\n"
+        ]
     },
     "function disconnect": {
         "prefix": "disconnect",
@@ -792,10 +800,13 @@
         "body": ["done(${1})${0}"],
         "description": ""
     },
-    "function encvalue": {
+    "encvalue": {
         "prefix": "encvalue",
-        "body": ["encvalue(${1})${0}"],
-        "description": ""
+        "body": ["encvalue(${1:inpar}, ${2:encoding_info}, ${3:dynamic_encoding})${0}"],
+        "description": [
+            "encvalue(in template (value) any_type inpar, in universal charstring encoding_info := \"\", in universal charstring dynamic_encoding := \"\") return bitstring",
+            "* an error would occur if there is no existing encoding function for actual type of inpar\n\n"
+        ]
     },
     "function encvalue_o": {
         "prefix": "encvalue_o",

--- a/syntaxes/ttcn.tmLanguage.json
+++ b/syntaxes/ttcn.tmLanguage.json
@@ -321,7 +321,7 @@
                     "match": "(?<=[\\[])\\s*([[:alpha:]][[:word:]\\-\\+[:space:]]*)\\s*(?=[\\]])"
                 },
                 {
-                    "name": "keyword.other.class.square.dot.ttcn",
+                    "name": "entity.name.function.square.dot.ttcn",
                     "match": "(?<=[\\{\\(\\[\\][:space:]\\;]|^)([[:alpha:]][[:word:]]*)(?=\\[\\S+\\][\\.])"
                 },
                 {
@@ -334,7 +334,7 @@
                 },
                 {
                     "name": "keyword.other.method.dot.ttcn",
-                    "match": "(?<=[\\.])(?!infinity|not_a_number)([[:alpha:]][[:word:]]*)\\s*(?=[\\s])"
+                    "match": "(?<=[\\.])(?!infinity|not_a_number)([[:alpha:]][[:word:]]*)\\s*(?=[\\s\\.\\,\\)\\]])"
                 },
                 {
                     "name": "entity.name.method.round.ttcn",

--- a/syntaxes/ttcn.tmLanguage.json
+++ b/syntaxes/ttcn.tmLanguage.json
@@ -338,7 +338,7 @@
                 },
                 {
                     "name": "entity.name.method.round.ttcn",
-                    "match": "(?<=^|[[:space:]\\{\\(\\[\\.])([[:alpha:]][[:word:]]*)\\s*(?=[\\(])(?!\\s*\\S+\\s*\\.\\.)"
+                    "match": "(?<=^|[[:space:]\\{\\(\\[\\.])(?!\\+|mod|rem|not|and|or|xor|not4b|and4b|or4b|xor4b)([[:alpha:]][[:word:]]*)\\s*(?=[\\(])(?!\\s*\\S+\\s*\\.\\.)"
                 }
             ]
         },
@@ -424,9 +424,14 @@
                     "match": "\\.{2}"
                 },
                 {
-                    "comment": "arithmetic operators [+-*/] (mod,rem)",
+                    "comment": "arithmetic operators [+-*/]",
                     "name": "keyword.operator.arithmetic.ttcn",
-                    "match": "\\b\\s*(\\+|-|\\*|/|mod|rem)\\s*\\b"
+                    "match": "[\\+\\-\\*\\/](?![\\*\\/])"
+                },
+                {
+                    "comment": "arithmetic operators (mod, rem)",
+                    "name": "keyword.operator.arithmetic.ttcn",
+                    "match": "(\\b(mod|rem)\\b)"
                 },
                 {
                     "comment": "string operators [&]",

--- a/syntaxes/ttcn.tmLanguage.json
+++ b/syntaxes/ttcn.tmLanguage.json
@@ -72,7 +72,7 @@
                 },
                 {
                     "name": "keyword.other.ttcn",
-                    "match": "(?x) \\b(char|charstring|class|component|configuration|conjunct|cont|continue|control)\\b"
+                    "match": "(?x) \\b(char|charstring|component|conjunct|cont|continue|control)\\b"
                 },
                 {
                     "name": "keyword.other.ttcn",
@@ -141,6 +141,11 @@
                 {
                     "name": "keyword.other.ttcn",
                     "match": "(?x) \\b(wait|with)\\b"
+                },
+                {
+                    "comment": "Custom ambiguous keywords",
+                    "name": "keyword.other.ttcn",
+                    "match": "(?x) \\b(class|configuration)\\b(?!([\\.\\(]|\\s*:))"
                 },
                 {
                     "include": "#user-keyword"

--- a/syntaxes/ttcn.tmLanguage.json
+++ b/syntaxes/ttcn.tmLanguage.json
@@ -132,7 +132,7 @@
                 },
                 {
                     "name": "keyword.other.ttcn",
-                    "match": "(?x) \\b(universal|unmap|until)\\b"
+                    "match": "(?x) \\b(universal|until)\\b"
                 },
                 {
                     "name": "keyword.other.ttcn",
@@ -231,7 +231,7 @@
                 },
                 {
                     "name": "entity.name.method.ttcn",
-                    "match": "(?x) \\b(unichar2int|unichar2oct|union)\\b"
+                    "match": "(?x) \\b(unichar2int|unichar2oct|union|unmap)\\b"
                 },
                 {
                     "name": "entity.name.method.ttcn",


### PR DESCRIPTION
± Fixed missing highlight for arithmetic operators
± Fixed incorrect highlight for unmap keyword
± Fixed inconsistent highlighting for user-defined keywords
\+ Added an exception for keywords class, configuration
± Improve snippets